### PR TITLE
download page doesnot show the qwebtest icon

### DIFF
--- a/static/css/less/_page-index.less
+++ b/static/css/less/_page-index.less
@@ -245,9 +245,6 @@
 				overflow: hidden;
 				width: 193px;
 				margin-bottom: 20px;
-				.resource_qwebtest_sprited {
-					.resource_sync_sprited;
-				}
 				p {
 					color: @64;
 					line-height: 18px;

--- a/static/css/less/_reset.less
+++ b/static/css/less/_reset.less
@@ -15,3 +15,8 @@ a:hover {
 img {
 	border:none;
 }
+
+// qwebtest没有图标，暂时用sync的样式
+.resource_qwebtest_sprited {
+	.resource_sync_sprited;
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -24,6 +24,12 @@ a:hover {
 img {
   border: none;
 }
+.resource_qwebtest_sprited {
+  background: url('../image/css-sprite.png') no-repeat;
+  background-position: 0px -1853px;
+  width: 27px;
+  height: 27px;
+}
 .pull-right {
   float: right;
 }
@@ -1457,13 +1463,6 @@ div.api-resource .social-resource .author {
   overflow: hidden;
   width: 193px;
   margin-bottom: 20px;
-}
-.container.index .cell.cli ul li .resource_qwebtest_sprited,
-.container.docs .cell.cli ul li .resource_qwebtest_sprited {
-  background: url('../image/css-sprite.png') no-repeat;
-  background-position: 0px -1853px;
-  width: 27px;
-  height: 27px;
 }
 .container.index .cell.cli ul li p,
 .container.docs .cell.cli ul li p {


### PR DESCRIPTION
将qwebtest的图标暂时用sync图标代用，在index和download页面。
