### PR TITLE
add put_data mimetype

### DIFF
--- a/docs/v6/sdk/python-sdk.md
+++ b/docs/v6/sdk/python-sdk.md
@@ -239,7 +239,7 @@ assert ret['key'] == key
 key = ''
 data = 'hello bubby!'
 token = q.upload_token(bucket_name, key)
-ret, info = put_data(token, key, data, check_crc=True)
+ret, info = put_data(token, key, data, mime_type="application/octet-stream", check_crc=True)
 print(info)
 assert ret['key'] == key
 


### PR DESCRIPTION
用户反馈python sdk put_data函数在文档中没有写 可以指定上传文件mimetype的参数，所以这边添加一下。
